### PR TITLE
Include "micronaut-context" instead of "micronaut-runtime"

### DIFF
--- a/mayflower/build.gradle.kts
+++ b/mayflower/build.gradle.kts
@@ -26,7 +26,7 @@ dependencies {
     annotationProcessor("io.micronaut:micronaut-inject-java")
 
     api("io.micronaut", "micronaut-inject-java")
-    api("io.micronaut", "micronaut-runtime")
+    api("io.micronaut", "micronaut-context")
 
     compileOnly(libs.paper)
 }


### PR DESCRIPTION
This pr refactors the dependency to only include `micronaut-context` instead of `micronaut-runtime`. This module has all needed functionality without including unnecessary dependencies such as `micronaut-http`.