### PR TITLE
Environments and Configuration

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -47,6 +47,7 @@
       <option name="BINARY_OPERATION_WRAP" value="1" />
       <option name="TERNARY_OPERATION_WRAP" value="5" />
       <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true" />
+      <option name="KEEP_SIMPLE_CLASSES_IN_ONE_LINE" value="true" />
       <option name="ARRAY_INITIALIZER_WRAP" value="1" />
       <option name="ARRAY_INITIALIZER_LBRACE_ON_NEXT_LINE" value="true" />
       <option name="ARRAY_INITIALIZER_RBRACE_ON_NEXT_LINE" value="true" />
@@ -58,8 +59,6 @@
       <option name="PARAMETER_ANNOTATION_WRAP" value="2" />
       <option name="VARIABLE_ANNOTATION_WRAP" value="2" />
       <option name="ENUM_CONSTANTS_WRAP" value="2" />
-      <option name="BUILDER_METHODS" value="min,max,toArray,map,collect,toList,count,limit,filter,anyMatch,flatMap,forEach,findAny,skip,peek,reduce,distinct,findFirst,allMatch,sorted,forEachOrdered,mapToInt,mapToLong,mapToDouble,mapMulti,takeWhile,dropWhile,noneMatch,flatMapToInt,flatMapToDouble,flatMapToLong,mapMultiToInt,mapMultiToLong,mapMultiToDouble,iterator,spliterator,close,parallel,onClose,sequential,isParallel,unordered,sum,mapToObj,boxed,asLongStream,asDoubleStream,average,summaryStatistics,add,accept,build,andThen" />
-      <option name="KEEP_BUILDER_METHODS_INDENTS" value="true" />
       <option name="WRAP_ON_TYPING" value="1" />
       <option name="SOFT_MARGINS" value="80" />
       <arrangement>
@@ -74,6 +73,19 @@
           </group>
         </groups>
         <rules>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <FIELD>true</FIELD>
+                  <FINAL>true</FINAL>
+                  <NAME>log</NAME>
+                  <PRIVATE>true</PRIVATE>
+                  <STATIC>true</STATIC>
+                </AND>
+              </match>
+            </rule>
+          </section>
           <section>
             <rule>
               <match>
@@ -331,13 +343,6 @@
                   <CLASS>true</CLASS>
                   <STATIC>true</STATIC>
                 </AND>
-              </match>
-            </rule>
-          </section>
-          <section>
-            <rule>
-              <match>
-                <CLASS>true</CLASS>
               </match>
             </rule>
           </section>

--- a/mayflower/src/main/java/io/github/madethoughts/mayflower/configuration/ConfigMigration.java
+++ b/mayflower/src/main/java/io/github/madethoughts/mayflower/configuration/ConfigMigration.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.madethoughts.mayflower.configuration;
+
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.plugin.java.JavaPlugin;
+
+/**
+ Implementations of this interface are config migrations, which will update the config from one to the next specific
+ version. After all migrations, the config is written back to the file.
+ @see Migration
+ */
+@FunctionalInterface
+public interface ConfigMigration {
+    /**
+     @param config The current configuration, returned from {@link JavaPlugin#getConfig()} and modified by previous
+     migrations. The default version of this {@link FileConfiguration} is the jar's one. That one generated at
+     compile time from your {@link PluginConfig} classes.
+     */
+    void migrate(FileConfiguration config);
+}

--- a/mayflower/src/main/java/io/github/madethoughts/mayflower/configuration/ConfigPropertySource.java
+++ b/mayflower/src/main/java/io/github/madethoughts/mayflower/configuration/ConfigPropertySource.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.madethoughts.mayflower.configuration;
+
+import io.github.madethoughts.mayflower.plugin.MayflowerPlugin;
+import io.micronaut.context.env.PropertySource;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Iterator;
+
+/**
+ Loads values from the plugin config.
+ */
+public class ConfigPropertySource implements PropertySource {
+    private final MayflowerPlugin mayflowerPlugin;
+
+    /**
+     @param mayflowerPlugin The {@link MayflowerPlugin} instance
+     */
+    public ConfigPropertySource(MayflowerPlugin mayflowerPlugin) {
+        this.mayflowerPlugin = mayflowerPlugin;
+    }
+
+    @Override
+    public String getName() {
+        return "Plugin config";
+    }
+
+    @Override
+    public @Nullable Object get(String key) {
+        if (!key.startsWith(PluginConfig.PLUGIN_PREFIX)) return null;
+        // normally we have to subtract one from the position, but we need to remove the . after the plugin prefix,
+        // so we're actually adding one position if we don't subtract one
+        return mayflowerPlugin.getConfig().get(key.substring(PluginConfig.PLUGIN_PREFIX.length()));
+    }
+
+    @NotNull
+    @Override
+    public Iterator<String> iterator() {
+        return mayflowerPlugin.getConfig().getKeys(true)
+                .stream()
+                .map("plugin.%s"::formatted)
+                .iterator();
+    }
+}

--- a/mayflower/src/main/java/io/github/madethoughts/mayflower/configuration/Default.java
+++ b/mayflower/src/main/java/io/github/madethoughts/mayflower/configuration/Default.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.madethoughts.mayflower.configuration;
+
+import io.micronaut.context.annotation.AliasFor;
+import io.micronaut.core.bind.annotation.Bindable;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ This annotation defines the default value of a configuration entry.
+ It's the same as using {@link Bindable#defaultValue()}
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.ANNOTATION_TYPE, ElementType.PARAMETER, ElementType.METHOD})
+@Bindable
+public @interface Default {
+    /**
+     @return The default value
+     */
+    @AliasFor(annotation = Bindable.class, member = "defaultValue")
+    String value();
+}

--- a/mayflower/src/main/java/io/github/madethoughts/mayflower/configuration/DefaultConfigInitializer.java
+++ b/mayflower/src/main/java/io/github/madethoughts/mayflower/configuration/DefaultConfigInitializer.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.madethoughts.mayflower.configuration;
+
+import io.github.madethoughts.mayflower.configuration.internal.Configs;
+import io.github.madethoughts.mayflower.internal.Preconditions;
+import io.github.madethoughts.mayflower.lifecycle.event.internal.PreLoadEvent;
+import io.github.madethoughts.mayflower.plugin.MayflowerPlugin;
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.context.event.ApplicationEventListener;
+import io.micronaut.core.io.ResourceLoader;
+import io.micronaut.inject.BeanDefinition;
+import io.micronaut.inject.qualifiers.Qualifiers;
+import jakarta.inject.Singleton;
+import org.bukkit.configuration.InvalidConfigurationException;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Comparator;
+
+/**
+ This listener is responsibly for setting up and migrating the plugin's config.
+ */
+@Singleton
+public class DefaultConfigInitializer implements ApplicationEventListener<PreLoadEvent> {
+
+    private static final Logger log = LoggerFactory.getLogger(DefaultConfigInitializer.class);
+    private static final String CONFIG_YML = "config.yml";
+    private static final String DEFAULT_CONFIG_YML = "default-config.yml";
+    private final Path configPath;
+    private final ResourceLoader resourceLoader;
+    private final ApplicationContext context;
+    private final FileConfiguration configuration;
+
+    @SuppressWarnings("MissingJavadoc")
+    public DefaultConfigInitializer(MayflowerPlugin mayflowerPlugin, ResourceLoader resourceLoader) {
+        configPath = mayflowerPlugin.getDataFolder().toPath().resolve(CONFIG_YML);
+        this.resourceLoader = resourceLoader;
+        this.context = mayflowerPlugin.applicationContext();
+        configuration = mayflowerPlugin.getConfig();
+    }
+
+    private static double readVersion(FileConfiguration config) {
+        var version = config.get("version");
+        Preconditions.checkCondition(() -> version instanceof Double,
+                "'version' field of config must be type double, eg. `version: 3.6`; not `version: '3.6'` or something"
+        );
+        return (double) version;
+    }
+
+    @Override
+    public void onApplicationEvent(PreLoadEvent event) {
+        var defaultConfigOpt = resourceLoader.getResourceAsStream(DEFAULT_CONFIG_YML);
+
+        if (defaultConfigOpt.isEmpty()) {
+            log.info("No default config found in jar, skip config setup");
+            return;
+        }
+
+        try (var defaultConfigStream = defaultConfigOpt.orElseThrow()) {
+            var defaultConfig = new String(defaultConfigStream.readAllBytes(), StandardCharsets.UTF_8);
+            if (Files.exists(configPath)) {
+                migrate(defaultConfig);
+            } else {
+                Files.createDirectories(configPath.getParent());
+                Files.writeString(configPath, defaultConfig);
+            }
+        } catch (IOException | InvalidConfigurationException e) {
+            log.error("Error copying default config or migrating config", e);
+        }
+    }
+
+    private void migrate(String defaultConfigString) throws InvalidConfigurationException, IOException {
+        var defaultConfig = new YamlConfiguration();
+        defaultConfig.loadFromString(defaultConfigString);
+
+        var currentVersion = readVersion(configuration);
+        var latestVersion = readVersion(defaultConfig);
+
+        validateDefaultConfigVersion(latestVersion);
+
+        Preconditions.checkCondition(() -> currentVersion <= latestVersion,
+                "Current config is newer than latest config class version."
+        );
+
+        // no migrations needed
+        //noinspection FloatingPointEquality
+        if (currentVersion == latestVersion) return;
+        log.info("Starting migration from {} to {}", currentVersion, latestVersion);
+
+        backupConfig(currentVersion);
+
+        // set default config as new default config
+        configuration.addDefaults(defaultConfig);
+
+        // check if versions are different major versions. If they are, run config migrations.
+        if (1 < latestVersion - currentVersion) {
+            log.info("Starting major version migration, this will add new, remove, rename or modify existing options.");
+            runConfigMigrations(currentVersion, latestVersion);
+        } else {
+            log.info("No breaking config version detected, only add new config options... ");
+        }
+
+        // cleanup config -- removing all keys that are not in default config
+        cleanup(defaultConfig);
+
+        configuration.options().copyDefaults(true);
+        configuration.set("version", latestVersion);
+        configuration.save(configPath.toFile());
+        log.info("Successfully migrated config from {} to {}", currentVersion, latestVersion);
+    }
+
+    private void backupConfig(double currentVersion) throws IOException {
+        var backupDir = configPath.getParent().resolve("config_backups");
+        var date = DateTimeFormatter.ISO_LOCAL_DATE.format(LocalDate.now());
+        var backupName = "%s+%s_config.yml".formatted(currentVersion, date);
+        var backupPath = backupDir.resolve(backupName);
+        log.info("Creating backup '{}' of config with version {}", backupName, currentVersion);
+
+        Files.createDirectories(backupDir);
+        if (Files.exists(backupPath)) {
+            log.info("Today's config backup already exists, overriding...");
+        }
+        configuration.save(backupPath.toFile());
+    }
+
+    private void validateDefaultConfigVersion(double defaultConfigVersion) {
+        context.getBeanDefinitions(Object.class, Qualifiers.byStereotype(PluginConfig.class))
+               .stream()
+               .filter(Configs::isRoot)
+               .map(Configs::version)
+               .findAny()
+               .ifPresent(pluginConfigVersion -> Preconditions.checkCondition(
+                       () -> pluginConfigVersion == defaultConfigVersion,
+                       "Default config version is unequal latest version from plugin config classes."
+               ));
+    }
+
+    private void cleanup(FileConfiguration defaultConfig) {
+        log.info("Starting config cleanup, all unnecessary options will be removed.");
+        for (var key : configuration.getKeys(true)) {
+            if (!defaultConfig.contains(key)) {
+                log.info("Removed option: {}", key);
+                configuration.set(key, null);
+            }
+        }
+    }
+
+    private void runConfigMigrations(double currentVersion, double latestVersion) {
+        var migrations =
+                context.getBeanDefinitions(ConfigMigration.class, Qualifiers.byStereotype(Migration.class))
+                       .stream()
+                       .map(def -> new Pair(def.intValue(Migration.class).orElseThrow(), def))
+                       .filter(pair -> pair.version() > currentVersion)
+                       .sorted(Comparator.comparingDouble(Pair::version))
+                       .toList();
+
+        Preconditions.checkCondition(() -> (int) (latestVersion - currentVersion) == migrations.size(),
+                "Missing major config version migrations found."
+        );
+        for (var migration : migrations) {
+            var version = migration.version();
+            var definition = migration.definition();
+            log.info("Running config migration: {} -> {} : {}", version - 1, version, definition.getName());
+            context.getBean(definition.getBeanType()).migrate(configuration);
+        }
+    }
+
+    private record Pair(double version, BeanDefinition<? extends ConfigMigration> definition) {}
+}

--- a/mayflower/src/main/java/io/github/madethoughts/mayflower/configuration/Migration.java
+++ b/mayflower/src/main/java/io/github/madethoughts/mayflower/configuration/Migration.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.madethoughts.mayflower.configuration;
+
+import io.micronaut.aop.Adapter;
+import io.micronaut.core.annotation.Indexed;
+import jakarta.inject.Singleton;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ This annotation indicates, that this class implements {@link ConfigMigration} and is therefore a config migration.
+ The {@link Migration#value()} field holds the new version, this migration will update the config to. The old version
+ is the previous version. For example: {@code @Migration(3)} will update the config from version 2.x to 3
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Adapter(ConfigMigration.class)
+@Indexed(ConfigMigration.class)
+@Singleton
+public @interface Migration {
+    /**
+     @return The new config major version.
+     */
+    int value();
+}

--- a/mayflower/src/main/java/io/github/madethoughts/mayflower/configuration/PluginConfig.java
+++ b/mayflower/src/main/java/io/github/madethoughts/mayflower/configuration/PluginConfig.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.madethoughts.mayflower.configuration;
+
+import io.micronaut.context.annotation.AliasFor;
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.core.annotation.AccessorsStyle;
+import io.micronaut.core.version.annotation.Version;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ This annotation indicates, that this configuration is the plugin's config. The values for this config will also be
+ loaded from the "config.yml" file in the plugins' directory. Also, all entries of this configuration need a default
+ value, for that {@link Default} can be used. The corresponding "config.yml" will have default values based on them.
+ <p>
+ All {@link PluginConfig} implementations must have a {@link Version} annotation. The version format is "minor.major"
+ and "number.number". The semantics are equal to schematic versioning.
+ <p>
+ Major version bumps should only be made if
+ breaking changes are applied, for example removing an option, renaming or changing the purpose. For every major
+ version update a {@link ConfigMigration} must be provided.
+ <p>
+ Minor version bumps should only be made if non-breaking changes are applied, for example adding a new option or
+ changing the default value.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.FIELD})
+@ConfigurationProperties(PluginConfig.PLUGIN_PREFIX)
+@AccessorsStyle(readPrefixes = "")
+public @interface PluginConfig {
+
+    /**
+     The prefix used to store plugin config properties
+     */
+    String PLUGIN_PREFIX = "plugin";
+
+    // @formatter:off
+    /**
+     The value field holds the subcategory of the plugin config. "" (default) means the root config "plugin".
+     <blockquote><pre>
+     &#64;PluginConfig
+     class PluginConfigFile {
+         &#64;PluginConfig("foo")
+         class FooSection {
+             // entries
+         }
+     }
+     </pre></blockquote>
+     In this example FooSection corresponds to "plugin.foo".
+     @return The subcategory
+     */
+    // @formatter:on
+    @AliasFor(annotation = ConfigurationProperties.class, member = "value")
+    String value() default "";
+
+    /**
+     @return the version of this config, this field must be set at the root level
+     */
+    double version() default -1;
+
+    /**
+     The value of this field will be mapped to {@link AccessorsStyle#readPrefixes()}
+
+     @return The read prefix
+     */
+    @AliasFor(annotation = AccessorsStyle.class, member = "readPrefixes")
+    String[] readPrefixes() default "";
+}

--- a/mayflower/src/main/java/io/github/madethoughts/mayflower/configuration/PluginConfig.java
+++ b/mayflower/src/main/java/io/github/madethoughts/mayflower/configuration/PluginConfig.java
@@ -19,7 +19,6 @@ package io.github.madethoughts.mayflower.configuration;
 import io.micronaut.context.annotation.AliasFor;
 import io.micronaut.context.annotation.ConfigurationProperties;
 import io.micronaut.core.annotation.AccessorsStyle;
-import io.micronaut.core.version.annotation.Version;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -27,19 +26,21 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- This annotation indicates, that this configuration is the plugin's config. The values for this config will also be
- loaded from the "config.yml" file in the plugins' directory. Also, all entries of this configuration need a default
- value, for that {@link Default} can be used. The corresponding "config.yml" will have default values based on them.
- <p>
- All {@link PluginConfig} implementations must have a {@link Version} annotation. The version format is "minor.major"
- and "number.number". The semantics are equal to schematic versioning.
- <p>
- Major version bumps should only be made if
- breaking changes are applied, for example removing an option, renaming or changing the purpose. For every major
- version update a {@link ConfigMigration} must be provided.
- <p>
- Minor version bumps should only be made if non-breaking changes are applied, for example adding a new option or
- changing the default value.
+This annotation indicates, that this configuration is the plugin's config. The values for this config will also be
+loaded from the "config.yml" file in the plugins' directory. Also, all entries of this configuration need a default
+value, for that {@link Default} can be used. The corresponding "config.yml" will have default values based on them.
+<p>
+The "root" {@link PluginConfig} implementations must have the version field set to a positive number. The version
+ format is "major
+.minor"
+and "number.number". The semantics are equal to schematic versioning.
+<p>
+Major version bumps should only be made if
+breaking changes are applied, for example removing an option, renaming or changing the purpose. For every major
+version update a {@link ConfigMigration} must be provided.
+<p>
+Minor version bumps should only be made if non-breaking changes are applied, for example adding a new option or
+changing the default value.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE, ElementType.FIELD})

--- a/mayflower/src/main/java/io/github/madethoughts/mayflower/configuration/internal/Configs.java
+++ b/mayflower/src/main/java/io/github/madethoughts/mayflower/configuration/internal/Configs.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.madethoughts.mayflower.configuration.internal;
+
+import io.github.madethoughts.mayflower.configuration.PluginConfig;
+import io.micronaut.core.annotation.AnnotationSource;
+
+/**
+ Configuration utility classes
+ */
+public final class Configs {
+    private Configs() {
+    }
+
+    /**
+     This method assumes, that the annotation source contains a {@link PluginConfig}
+
+     @param metadata The {@link AnnotationSource}
+     @return the version, specified by {@link PluginConfig}
+     */
+    public static double version(AnnotationSource metadata) {
+        return metadata.getAnnotation(PluginConfig.class).getRequiredValue("version", double.class);
+    }
+
+    /**
+     @param source The {@link  AnnotationSource}
+     @return whether this is the root interface
+     */
+    public static boolean isRoot(AnnotationSource source) {
+        return source.getAnnotation(PluginConfig.class)
+                .isTrue("root");
+    }
+}

--- a/mayflower/src/main/java/io/github/madethoughts/mayflower/configuration/internal/package-info.java
+++ b/mayflower/src/main/java/io/github/madethoughts/mayflower/configuration/internal/package-info.java
@@ -14,22 +14,4 @@
  * limitations under the License.
  */
 
-package io.github.madethoughts.mayflower.testplugin;
-
-import io.github.madethoughts.mayflower.listener.McEventListener;
-import io.github.madethoughts.mayflower.listener.McListener;
-import org.bukkit.event.player.PlayerJoinEvent;
-
-@SuppressWarnings("ALL")
-@McListener
-public class PlayerJoinListener implements McEventListener<PlayerJoinEvent> {
-    @Override
-    public void onEvent(PlayerJoinEvent event) {
-        event.getPlayer().sendMessage("manuell mc event listener");
-    }
-
-    @Override
-    public boolean isSupported(PlayerJoinEvent event) {
-        return false;
-    }
-}
+package io.github.madethoughts.mayflower.configuration.internal;

--- a/mayflower/src/main/java/io/github/madethoughts/mayflower/configuration/internal/visitors/DefaultConfigGenerator.java
+++ b/mayflower/src/main/java/io/github/madethoughts/mayflower/configuration/internal/visitors/DefaultConfigGenerator.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.madethoughts.mayflower.configuration.internal.visitors;
+
+import io.github.madethoughts.mayflower.configuration.PluginConfig;
+import io.github.madethoughts.mayflower.configuration.internal.Configs;
+import io.github.madethoughts.mayflower.internal.FileUtils;
+import io.micronaut.core.annotation.AnnotationValue;
+import io.micronaut.core.bind.annotation.Bindable;
+import io.micronaut.inject.ast.ClassElement;
+import io.micronaut.inject.ast.MemberElement;
+import io.micronaut.inject.ast.MethodElement;
+import io.micronaut.inject.visitor.TypeElementVisitor;
+import io.micronaut.inject.visitor.VisitorContext;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+import java.lang.annotation.RetentionPolicy;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+
+/**
+ This TypeElementVisitors generates a default config at compile time, consuming interfaces annotated with
+ {@link PluginConfig}.
+ */
+
+// service
+@SuppressWarnings("unused")
+public class DefaultConfigGenerator implements TypeElementVisitor<PluginConfig, Object> {
+
+    /**
+     The error message printed when the default value annotation is missing
+     */
+    public static final String MISSING_DEFAULT_VALUE_ERR =
+            "All members of @PluginConfig classes must be annotated with @Bindable(defaultValue = ...) or @Default(...)";
+    /**
+     The error message printed when the version isn't specified
+     */
+    public static final String MISSING_VERSION_ERR =
+            "@PluginConfig on root interface need the PluginConfig#version field set to a positive number!";
+
+    /**
+     The error message printed when unequal versions are found
+     */
+    public static final String UNEQUAL_VERSIONS_ERR = "Unequal versions found: %s and %s";
+    private final Collection<MethodElement> alreadyInspected = new HashSet<>();
+    private final YamlConfiguration defaultValues = new YamlConfiguration();
+
+    private static String configPath(MemberElement element) {
+        var sections = new ArrayList<String>();
+        sections.add(element.getName());
+
+        var currentElement = element.getDeclaringType();
+        while (isInner(currentElement)) {
+            currentElement.stringValue(PluginConfig.class).ifPresent(sections::add);
+            currentElement = currentElement.getEnclosingType().orElseThrow();
+        }
+
+        Collections.reverse(sections);
+        return String.join(".", sections);
+    }
+
+    private static boolean isInner(ClassElement element) {
+        return element.getEnclosingType()
+                      .filter(outer -> outer.hasAnnotation(PluginConfig.class))
+                      .isPresent();
+    }
+
+    @Override
+    public void visitClass(ClassElement element, VisitorContext context) {
+        // skip version validation if class is not root nor @PluginConfig class
+        if (!element.hasAnnotation(PluginConfig.class) || isInner(element)) return;
+
+        // markt class as config root
+        var rootValue = AnnotationValue.builder(element.getAnnotation(PluginConfig.class), RetentionPolicy.RUNTIME)
+                                  .member("root", true)
+                                  .build();
+        element.annotate(rootValue);
+
+        var version = Configs.version(element);
+        if (0 > version) {
+            context.fail(MISSING_VERSION_ERR, element);
+            return;
+        }
+        if (!defaultValues.contains("version")) defaultValues.set("version", version);
+
+        var configVersion = defaultValues.getDouble("version");
+        if (configVersion != version) {
+            context.fail(UNEQUAL_VERSIONS_ERR.formatted(configVersion, version), element);
+        }
+    }
+
+    @Override
+    public void visitMethod(MethodElement element, VisitorContext context) {
+        if (!alreadyInspected.add(element)) return; // skip already inspected methods
+
+        // don't inspect references to other configs
+        if (element.getReturnType().hasAnnotation(PluginConfig.class)) return;
+
+        element.getValue(Bindable.class, "defaultValue")
+               .ifPresentOrElse(defaultVal -> defaultValues.set(configPath(element), defaultVal),
+                       () -> context.fail(MISSING_DEFAULT_VALUE_ERR, element)
+               );
+    }
+
+    @Override
+    public void finish(VisitorContext visitorContext) {
+        var outputPath = visitorContext.getClassesOutputPath().orElseThrow()
+                                       .resolve("default-config.yml");
+        FileUtils.writeString(outputPath, defaultValues.saveToString());
+    }
+}

--- a/mayflower/src/main/java/io/github/madethoughts/mayflower/configuration/internal/visitors/package-info.java
+++ b/mayflower/src/main/java/io/github/madethoughts/mayflower/configuration/internal/visitors/package-info.java
@@ -13,23 +13,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package io.github.madethoughts.mayflower.configuration.internal.visitors;
 
-package io.github.madethoughts.mayflower.testplugin;
-
-import io.github.madethoughts.mayflower.listener.McEventListener;
-import io.github.madethoughts.mayflower.listener.McListener;
-import org.bukkit.event.player.PlayerJoinEvent;
-
-@SuppressWarnings("ALL")
-@McListener
-public class PlayerJoinListener implements McEventListener<PlayerJoinEvent> {
-    @Override
-    public void onEvent(PlayerJoinEvent event) {
-        event.getPlayer().sendMessage("manuell mc event listener");
-    }
-
-    @Override
-    public boolean isSupported(PlayerJoinEvent event) {
-        return false;
-    }
-}

--- a/mayflower/src/main/java/io/github/madethoughts/mayflower/configuration/package-info.java
+++ b/mayflower/src/main/java/io/github/madethoughts/mayflower/configuration/package-info.java
@@ -14,22 +14,4 @@
  * limitations under the License.
  */
 
-package io.github.madethoughts.mayflower.testplugin;
-
-import io.github.madethoughts.mayflower.listener.McEventListener;
-import io.github.madethoughts.mayflower.listener.McListener;
-import org.bukkit.event.player.PlayerJoinEvent;
-
-@SuppressWarnings("ALL")
-@McListener
-public class PlayerJoinListener implements McEventListener<PlayerJoinEvent> {
-    @Override
-    public void onEvent(PlayerJoinEvent event) {
-        event.getPlayer().sendMessage("manuell mc event listener");
-    }
-
-    @Override
-    public boolean isSupported(PlayerJoinEvent event) {
-        return false;
-    }
-}
+package io.github.madethoughts.mayflower.configuration;

--- a/mayflower/src/main/java/io/github/madethoughts/mayflower/internal/FileUtils.java
+++ b/mayflower/src/main/java/io/github/madethoughts/mayflower/internal/FileUtils.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.madethoughts.mayflower.internal;
+
+import java.io.IOException;
+import java.nio.file.FileVisitOption;
+import java.nio.file.Files;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.function.BiPredicate;
+import java.util.stream.Stream;
+
+/**
+ Common file utils
+ */
+public final class FileUtils {
+
+    private FileUtils() {
+    }
+
+    /**
+     @param start the start
+     @param depth the depth
+     @param predicate the predicate
+     @return The {@link Stream<Path>} produces by {@link Files#find}
+     @see Files#find(Path, int, BiPredicate, FileVisitOption...)
+     */
+    public static Stream<Path> find(Path start, int depth, BiPredicate<Path, BasicFileAttributes> predicate) {
+        try {
+            return Files.find(start, depth, predicate);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     @param path The file path
+     @return the contents
+     @see Files#readString(Path)
+     */
+    public static String readString(Path path) {
+        try {
+            return Files.readString(path);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     @param path The files path
+     @param text the text to write
+     @see Files#writeString(Path, CharSequence, OpenOption...)
+     */
+    public static void writeString(Path path, String text) {
+        try {
+            Files.writeString(path, text);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/mayflower/src/main/java/io/github/madethoughts/mayflower/internal/Preconditions.java
+++ b/mayflower/src/main/java/io/github/madethoughts/mayflower/internal/Preconditions.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.madethoughts.mayflower.internal;
+
+import java.io.Serial;
+import java.util.function.Supplier;
+
+/**
+ Containing preconditions
+ */
+public final class Preconditions {
+    private Preconditions() {
+    }
+
+    /**
+     @param check   The condition to check
+     @param message The message that should be printed, if the condition fails
+     @throws PreconditionException if the condition fails
+     */
+    public static void checkCondition(Supplier<Boolean> check, String message) {
+        if (!check.get()) {
+            throw new PreconditionException(message);
+        }
+    }
+
+    /**
+     An Exception thrown by checks in this preconditions class
+     */
+    @SuppressWarnings("WeakerAccess")
+    public static final class PreconditionException extends RuntimeException {
+
+        @Serial
+        private static final long serialVersionUID = -368296224608747811L;
+
+        /**
+         @param message The error message
+         */
+        private PreconditionException(String message) {
+            super(message);
+        }
+    }
+}

--- a/mayflower/src/main/java/io/github/madethoughts/mayflower/internal/package-info.java
+++ b/mayflower/src/main/java/io/github/madethoughts/mayflower/internal/package-info.java
@@ -14,22 +14,7 @@
  * limitations under the License.
  */
 
-package io.github.madethoughts.mayflower.testplugin;
-
-import io.github.madethoughts.mayflower.listener.McEventListener;
-import io.github.madethoughts.mayflower.listener.McListener;
-import org.bukkit.event.player.PlayerJoinEvent;
-
-@SuppressWarnings("ALL")
-@McListener
-public class PlayerJoinListener implements McEventListener<PlayerJoinEvent> {
-    @Override
-    public void onEvent(PlayerJoinEvent event) {
-        event.getPlayer().sendMessage("manuell mc event listener");
-    }
-
-    @Override
-    public boolean isSupported(PlayerJoinEvent event) {
-        return false;
-    }
-}
+/**
+ This packages includes common internal stuff like utils
+ */
+package io.github.madethoughts.mayflower.internal;

--- a/mayflower/src/main/java/io/github/madethoughts/mayflower/lifecycle/event/internal/PreLoadEvent.java
+++ b/mayflower/src/main/java/io/github/madethoughts/mayflower/lifecycle/event/internal/PreLoadEvent.java
@@ -14,22 +14,15 @@
  * limitations under the License.
  */
 
-package io.github.madethoughts.mayflower.testplugin;
+package io.github.madethoughts.mayflower.lifecycle.event.internal;
 
-import io.github.madethoughts.mayflower.listener.McEventListener;
-import io.github.madethoughts.mayflower.listener.McListener;
-import org.bukkit.event.player.PlayerJoinEvent;
+import io.github.madethoughts.mayflower.lifecycle.event.LoadEvent;
+import io.micronaut.context.env.Environment;
 
-@SuppressWarnings("ALL")
-@McListener
-public class PlayerJoinListener implements McEventListener<PlayerJoinEvent> {
-    @Override
-    public void onEvent(PlayerJoinEvent event) {
-        event.getPlayer().sendMessage("manuell mc event listener");
-    }
-
-    @Override
-    public boolean isSupported(PlayerJoinEvent event) {
-        return false;
-    }
+/**
+ An event that is called before the {@link LoadEvent} is called.
+ This event should not depend on any setup made. Things like the plugin config are initialized in this state.
+ The {@link Environment} is refreshed after all listeners ran. (using {@link Environment#refresh()}
+ */
+public class PreLoadEvent {
 }

--- a/mayflower/src/main/java/io/github/madethoughts/mayflower/lifecycle/event/internal/package-info.java
+++ b/mayflower/src/main/java/io/github/madethoughts/mayflower/lifecycle/event/internal/package-info.java
@@ -14,22 +14,4 @@
  * limitations under the License.
  */
 
-package io.github.madethoughts.mayflower.testplugin;
-
-import io.github.madethoughts.mayflower.listener.McEventListener;
-import io.github.madethoughts.mayflower.listener.McListener;
-import org.bukkit.event.player.PlayerJoinEvent;
-
-@SuppressWarnings("ALL")
-@McListener
-public class PlayerJoinListener implements McEventListener<PlayerJoinEvent> {
-    @Override
-    public void onEvent(PlayerJoinEvent event) {
-        event.getPlayer().sendMessage("manuell mc event listener");
-    }
-
-    @Override
-    public boolean isSupported(PlayerJoinEvent event) {
-        return false;
-    }
-}
+package io.github.madethoughts.mayflower.lifecycle.event.internal;

--- a/mayflower/src/main/java/io/github/madethoughts/mayflower/plugin/MayflowerPlugin.java
+++ b/mayflower/src/main/java/io/github/madethoughts/mayflower/plugin/MayflowerPlugin.java
@@ -33,10 +33,19 @@ import org.bukkit.plugin.java.JavaPlugin;
  */
 public class MayflowerPlugin extends JavaPlugin {
 
+    /**
+     The plugin environment, indicating that this plugin runs on a minecraft server.
+     */
+    public static final String PLUGIN_ENVIRONMENT = "plugin";
+
     private final ApplicationContext applicationContext;
 
     protected MayflowerPlugin() {
-        applicationContext = ApplicationContext.run(getClassLoader()).start();
+        applicationContext = ApplicationContext.builder(getClassLoader(), PLUGIN_ENVIRONMENT)
+                                               .deduceEnvironment(false)
+                                               .banner(false)
+                                               .propertySources()
+                                               .start();
     }
 
     @Override

--- a/mayflower/src/main/java/io/github/madethoughts/mayflower/plugin/MayflowerPlugin.java
+++ b/mayflower/src/main/java/io/github/madethoughts/mayflower/plugin/MayflowerPlugin.java
@@ -16,9 +16,11 @@
 
 package io.github.madethoughts.mayflower.plugin;
 
+import io.github.madethoughts.mayflower.configuration.ConfigPropertySource;
 import io.github.madethoughts.mayflower.lifecycle.event.DisableEvent;
 import io.github.madethoughts.mayflower.lifecycle.event.EnableEvent;
 import io.github.madethoughts.mayflower.lifecycle.event.LoadEvent;
+import io.github.madethoughts.mayflower.lifecycle.event.internal.PreLoadEvent;
 import io.micronaut.context.ApplicationContext;
 import org.bukkit.plugin.java.JavaPlugin;
 
@@ -44,15 +46,20 @@ public class MayflowerPlugin extends JavaPlugin {
         applicationContext = ApplicationContext.builder(getClassLoader(), PLUGIN_ENVIRONMENT)
                                                .deduceEnvironment(false)
                                                .banner(false)
-                                               .propertySources()
-                                               .start();
+                                               .propertySources(new ConfigPropertySource(this))
+                                               .build();
     }
 
     @Override
     public final void onLoad() {
+        applicationContext.start();
+
         applicationContext.registerSingleton(this);
         applicationContext.registerSingleton(getServer());
 
+        applicationContext.getEventPublisher(PreLoadEvent.class).publishEvent(new PreLoadEvent());
+        // refresh the environment so configs are reloaded
+        applicationContext.getEnvironment().refresh();
         applicationContext.getEventPublisher(LoadEvent.class).publishEvent(new LoadEvent());
     }
 

--- a/mayflower/src/main/java/io/github/madethoughts/mayflower/plugin/yaml/McPluginVisitor.java
+++ b/mayflower/src/main/java/io/github/madethoughts/mayflower/plugin/yaml/McPluginVisitor.java
@@ -39,10 +39,18 @@ public class McPluginVisitor implements TypeElementVisitor<McPlugin, Object> {
     private static final String TEMPLATE_PLUGIN_YAML = "override.plugin.yml";
     private static final BiPredicate<Path, BasicFileAttributes> TEMPLATE_PLUGIN_YAML_PREDICATE =
             (path, basicFileAttributes) -> path.endsWith(Path.of("resources", TEMPLATE_PLUGIN_YAML));
+    public static final String INNER_CLASS_ERR = "@McPlugin is not permitted on inner classes";
     private final Yaml yaml = new Yaml();
 
     @Override
     public void visitClass(ClassElement element, VisitorContext context) {
+        // skip inner classes, the root class have to be annotated with this annotation
+        if (element.isInner()) {
+            if (element.hasAnnotation(McPlugin.class)) {
+                context.fail(INNER_CLASS_ERR, element);
+            }
+            return;
+        }
         var projectDir = context.getProjectDir().orElseThrow();
 
         // search for existing file

--- a/mayflower/src/main/java/module-info.java
+++ b/mayflower/src/main/java/module-info.java
@@ -6,6 +6,7 @@ module io.github.madethoughts.mayflower {
     requires io.micronaut.inject;
     requires io.micronaut.aop;
     requires io.micronaut.context;
+    requires io.micronaut.core;
 
     requires jakarta.inject;
     requires org.jetbrains.annotations;
@@ -17,6 +18,8 @@ module io.github.madethoughts.mayflower {
     exports io.github.madethoughts.mayflower.plugin;
     exports io.github.madethoughts.mayflower.listener;
     exports io.github.madethoughts.mayflower.lifecycle.event;
+    exports io.github.madethoughts.mayflower.configuration;
+    exports io.github.madethoughts.mayflower.lifecycle.event.internal;
 
     provides TypeElementVisitor with io.github.madethoughts.mayflower.plugin.yaml.McPluginVisitor;
 }

--- a/mayflower/src/main/java/module-info.java
+++ b/mayflower/src/main/java/module-info.java
@@ -19,7 +19,6 @@ module io.github.madethoughts.mayflower {
     exports io.github.madethoughts.mayflower.listener;
     exports io.github.madethoughts.mayflower.lifecycle.event;
     exports io.github.madethoughts.mayflower.configuration;
-    exports io.github.madethoughts.mayflower.lifecycle.event.internal;
 
     provides TypeElementVisitor with io.github.madethoughts.mayflower.plugin.yaml.McPluginVisitor;
 }

--- a/test_plugin/build.gradle.kts
+++ b/test_plugin/build.gradle.kts
@@ -21,11 +21,12 @@ plugins {
 
 dependencies {
     annotationProcessor(project(":mayflower"))
+    annotationProcessor(libs.paper)
+
     implementation(project(":mayflower"))
 
     compileOnly(libs.paper)
 }
-
 tasks {
     shadowJar {
         dependencies {

--- a/test_plugin/src/main/java/io/github/madethoughts/mayflower/testplugin/ConfigMigration2.java
+++ b/test_plugin/src/main/java/io/github/madethoughts/mayflower/testplugin/ConfigMigration2.java
@@ -16,20 +16,15 @@
 
 package io.github.madethoughts.mayflower.testplugin;
 
-import io.github.madethoughts.mayflower.listener.McEventListener;
-import io.github.madethoughts.mayflower.listener.McListener;
-import org.bukkit.event.player.PlayerJoinEvent;
+import io.github.madethoughts.mayflower.configuration.ConfigMigration;
+import io.github.madethoughts.mayflower.configuration.Migration;
+import org.bukkit.configuration.file.FileConfiguration;
 
 @SuppressWarnings("ALL")
-@McListener
-public class PlayerJoinListener implements McEventListener<PlayerJoinEvent> {
+@Migration(2)
+public class ConfigMigration2 implements ConfigMigration {
     @Override
-    public void onEvent(PlayerJoinEvent event) {
-        event.getPlayer().sendMessage("manuell mc event listener");
-    }
-
-    @Override
-    public boolean isSupported(PlayerJoinEvent event) {
-        return false;
+    public void migrate(FileConfiguration config) {
+        config.set("migrate2", "refreshed values arrrrasdfffffffff");
     }
 }

--- a/test_plugin/src/main/java/io/github/madethoughts/mayflower/testplugin/ConfigMigration3.java
+++ b/test_plugin/src/main/java/io/github/madethoughts/mayflower/testplugin/ConfigMigration3.java
@@ -16,20 +16,15 @@
 
 package io.github.madethoughts.mayflower.testplugin;
 
-import io.github.madethoughts.mayflower.listener.McEventListener;
-import io.github.madethoughts.mayflower.listener.McListener;
-import org.bukkit.event.player.PlayerJoinEvent;
+import io.github.madethoughts.mayflower.configuration.ConfigMigration;
+import io.github.madethoughts.mayflower.configuration.Migration;
+import org.bukkit.configuration.file.FileConfiguration;
 
 @SuppressWarnings("ALL")
-@McListener
-public class PlayerJoinListener implements McEventListener<PlayerJoinEvent> {
+@Migration(3)
+public class ConfigMigration3 implements ConfigMigration {
     @Override
-    public void onEvent(PlayerJoinEvent event) {
-        event.getPlayer().sendMessage("manuell mc event listener");
-    }
-
-    @Override
-    public boolean isSupported(PlayerJoinEvent event) {
-        return false;
+    public void migrate(FileConfiguration config) {
+        config.set("migrate3", "yeeeees");
     }
 }

--- a/test_plugin/src/main/java/io/github/madethoughts/mayflower/testplugin/ConfigMigration4.java
+++ b/test_plugin/src/main/java/io/github/madethoughts/mayflower/testplugin/ConfigMigration4.java
@@ -16,20 +16,15 @@
 
 package io.github.madethoughts.mayflower.testplugin;
 
-import io.github.madethoughts.mayflower.listener.McEventListener;
-import io.github.madethoughts.mayflower.listener.McListener;
-import org.bukkit.event.player.PlayerJoinEvent;
+import io.github.madethoughts.mayflower.configuration.ConfigMigration;
+import io.github.madethoughts.mayflower.configuration.Migration;
+import org.bukkit.configuration.file.FileConfiguration;
 
 @SuppressWarnings("ALL")
-@McListener
-public class PlayerJoinListener implements McEventListener<PlayerJoinEvent> {
+@Migration(4)
+public class ConfigMigration4 implements ConfigMigration {
     @Override
-    public void onEvent(PlayerJoinEvent event) {
-        event.getPlayer().sendMessage("manuell mc event listener");
-    }
-
-    @Override
-    public boolean isSupported(PlayerJoinEvent event) {
-        return false;
+    public void migrate(FileConfiguration config) {
+        config.set("migrate4", "yeeeees");
     }
 }

--- a/test_plugin/src/main/java/io/github/madethoughts/mayflower/testplugin/ConfigTester.java
+++ b/test_plugin/src/main/java/io/github/madethoughts/mayflower/testplugin/ConfigTester.java
@@ -16,20 +16,24 @@
 
 package io.github.madethoughts.mayflower.testplugin;
 
-import io.github.madethoughts.mayflower.listener.McEventListener;
-import io.github.madethoughts.mayflower.listener.McListener;
-import org.bukkit.event.player.PlayerJoinEvent;
+import io.micronaut.context.annotation.Context;
+import jakarta.annotation.PostConstruct;
+import jakarta.inject.Singleton;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-@SuppressWarnings("ALL")
-@McListener
-public class PlayerJoinListener implements McEventListener<PlayerJoinEvent> {
-    @Override
-    public void onEvent(PlayerJoinEvent event) {
-        event.getPlayer().sendMessage("manuell mc event listener");
+@Singleton
+@Context
+public class ConfigTester {
+    private static final Logger log = LoggerFactory.getLogger(ConfigTester.class);
+    private final TestConfig testConfig;
+
+    public ConfigTester(TestConfig testConfig) {
+        this.testConfig = testConfig;
     }
 
-    @Override
-    public boolean isSupported(PlayerJoinEvent event) {
-        return false;
+    @PostConstruct
+    void init() {
+        log.info(testConfig.migrate4());
     }
 }

--- a/test_plugin/src/main/java/io/github/madethoughts/mayflower/testplugin/TestConfig.java
+++ b/test_plugin/src/main/java/io/github/madethoughts/mayflower/testplugin/TestConfig.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023 original authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.madethoughts.mayflower.testplugin;
+
+import io.github.madethoughts.mayflower.configuration.Default;
+import io.github.madethoughts.mayflower.configuration.PluginConfig;
+
+@SuppressWarnings("ALL")
+@PluginConfig(version = 4.4)
+public interface TestConfig {
+    @Default("test lol")
+    String foo();
+
+    @Default("new 1.4 option")
+    String newOption();
+
+    @Default("yeeeees")
+    String migrate2();
+    @Default("yeeeees")
+    String migrate3();
+    @Default("yeeeees")
+    String migrate4();
+
+    TestSection testSection();
+
+    @PluginConfig("test")
+    public interface TestSection {
+        @Default("12")
+        int bar();
+
+        @Default("asdfasdf")
+        String someOther();
+
+        InnerTest innertest();
+
+        @PluginConfig("innerTest")
+        public interface InnerTest {
+            @Default("barInner")
+            String barInnerVar();
+        }
+    }
+}

--- a/test_plugin/src/main/java/io/github/madethoughts/mayflower/testplugin/TestPlugin.java
+++ b/test_plugin/src/main/java/io/github/madethoughts/mayflower/testplugin/TestPlugin.java
@@ -16,25 +16,60 @@
 
 package io.github.madethoughts.mayflower.testplugin;
 
+import io.github.madethoughts.mayflower.configuration.Default;
+import io.github.madethoughts.mayflower.configuration.PluginConfig;
 import io.github.madethoughts.mayflower.lifecycle.event.EnableEvent;
+import io.github.madethoughts.mayflower.lifecycle.event.internal.PreLoadEvent;
 import io.github.madethoughts.mayflower.listener.McListener;
 import io.github.madethoughts.mayflower.plugin.MayflowerPlugin;
 import io.github.madethoughts.mayflower.plugin.McPlugin;
 import io.micronaut.runtime.event.annotation.EventListener;
 import org.bukkit.event.player.PlayerJoinEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @SuppressWarnings("ALL")
 @McPlugin(name = "MayflowerTestPlugin", version = "0.1", apiVersion = McPlugin.ApiVersion.V1_19, authors = "goldmensch")
 public class TestPlugin extends MayflowerPlugin {
+
+    private static final Logger log = LoggerFactory.getLogger(TestPlugin.class);
 
     @EventListener
     public void sendWorksMessage(EnableEvent event) {
         getLogger().info("Works, wuhu!");
     }
 
+    @EventListener
+    public void sendProperties(EnableEvent event) {
+        var property = applicationContext().containsProperty("test.val");
+        getSLF4JLogger().info("Property: {}", property);
+        getSLF4JLogger().info("Default loading: {}", applicationContext().getEnvironment().getPropertySourceLoaders());
+
+        var configFoo = getConfig().get("foo");
+        log.info("Config: {}", configFoo);
+
+        var foo = applicationContext().getBean(TestConfig.class).migrate2();
+        log.info("migrate2: {}", foo);
+
+        var propFoo = applicationContext().getProperty("plugin.foo", String.class);
+        log.info("prop: {}", propFoo);
+    }
+
+    @EventListener
+    public void testPreLoad(PreLoadEvent event) {
+        var foo = applicationContext().getBean(TestConfig.class).migrate2();
+        log.info("migrate2 (pre laod): {}", foo);
+    }
+
     @McListener
     public void test(PlayerJoinEvent event) {
         event.getPlayer().sendMessage("test");
+    }
+
+    @PluginConfig(version = 4.4)
+    public interface InnerConfig {
+        @Default("innerValue lol")
+        String innerClassValue();
     }
 
 }

--- a/test_plugin/src/main/java/module-info.java
+++ b/test_plugin/src/main/java/module-info.java
@@ -1,9 +1,11 @@
 module mayflower.test.plugin.main {
     requires java.logging;
+    requires org.slf4j;
 
     requires org.bukkit;
     requires io.github.madethoughts.mayflower;
 
+    requires io.micronaut.core;
     requires jakarta.annotation;
     requires io.micronaut.aop;
     requires io.micronaut.context;

--- a/test_plugin/src/main/resources/application.yaml
+++ b/test_plugin/src/main/resources/application.yaml
@@ -1,0 +1,1 @@
+test.val: true


### PR DESCRIPTION
This pr disables the automatic detection of environments, this could cause unexpected behavior and is not really useful in a plugin, furthermore this pr adds the ability to generate a default configuration at compile time, setting it up at runtime and defining migrations.

depends on #13 